### PR TITLE
Add share to options in map view

### DIFF
--- a/app/components/Map.js
+++ b/app/components/Map.js
@@ -174,12 +174,14 @@ export default class Map extends Component {
   }
 
   renderEditButton() {
-    const { updatePins, updateRecent, deletePin, setTarget, targetPin } = this.props;
+    const { friends, updatePins, updateRecent, deletePin, setTarget, targetPin, shareWithFriend } = this.props;
 
     return (
       <View style={styles.editButton}>
         <PinEditButton
           pin={this.state.selectedPin}
+          friends={friends}
+          shareWithFriend={shareWithFriend}
           updatePins={updatePins}
           updateRecent={updateRecent}
           deletePin={deletePin}

--- a/app/components/PinEditButton.js
+++ b/app/components/PinEditButton.js
@@ -1,5 +1,6 @@
 import React, { Component, AlertIOS , View, StyleSheet} from 'react-native';
 import Button from 'react-native-button';
+import { Actions } from 'react-native-router-flux';
 
 export default class PinEditButton extends Component{
   constructor(props) {
@@ -14,7 +15,7 @@ export default class PinEditButton extends Component{
   }
 
   render() {
-    const { pin, deletePin, hideButton, setTarget } = this.props;
+    const { pin, deletePin, friends, hideButton, setTarget, shareWithFriend } = this.props;
     return(
       <Button
         style={[styles.bubble, styles.button]}
@@ -31,6 +32,10 @@ export default class PinEditButton extends Component{
             {
               text: 'Edit Title',
               onPress: this.editTitle.bind(this)
+            },
+            {
+              text: 'Share',
+              onPress: () => { Actions.friends({ onPress: shareWithFriend.bind( null, pin ), friends: friends }) },
             },
             {
               text: 'Set Target',

--- a/app/components/PinList.js
+++ b/app/components/PinList.js
@@ -77,10 +77,11 @@ export default class PinList extends Component {
 
 
   renderItem(pin) {
-    const { updatePins, updateRecent, deletePin, setTarget, targetPin, friends, user } = this.props;
+    const { updatePins, updateRecent, deletePin, setTarget, targetPin, shareWithFriend, friends, user } = this.props;
     return (
         // pass down pin info to PinListItem
         <PinListItem
+          shareWithFriend={shareWithFriend}
           updatePins={updatePins}
           updateRecent={updateRecent}
           deletePin={deletePin}

--- a/app/components/PinListItem.js
+++ b/app/components/PinListItem.js
@@ -9,8 +9,6 @@ import React, {
 } from 'react-native';
 
 import { Actions } from 'react-native-router-flux';
-import FriendList from './FriendList';
-import { ref } from '../lib/db/db';
 import Location from '../lib/orientation/locationMath';
 
 
@@ -21,7 +19,7 @@ export default class PinListItem extends Component {
   }
 
   touchOptions() {
-    const { pin, friends, deletePin, setTarget, redraw } = this.props;
+    const { pin, friends, deletePin, setTarget, redraw, shareWithFriend } = this.props;
     AlertIOS.prompt(
         pin.title,
         '('+pin.longitude + ', ' + pin.latitude + ')',
@@ -35,7 +33,7 @@ export default class PinListItem extends Component {
         },
         {
           text: 'Share',
-          onPress: () => { Actions.friends({ onPress: this.shareWithFriend.bind( this, pin ), friends: friends }) },
+          onPress: () => { Actions.friends({ onPress: shareWithFriend.bind( null, pin ), friends: friends }) },
         },
         {
           text: 'Set Target',
@@ -52,35 +50,6 @@ export default class PinListItem extends Component {
         }],
         'plain-text'
       );
-  }
-
-  shareWithFriend( pin, friend ) {
-    const { user } = this.props;
-    if( typeof user.id !== 'string' ) {
-      console.log( 'shareWithFriend: user id must be a string' );
-      return null;
-    }
-    if( typeof friend.id !== 'string' ) {
-      console.log( 'shareWithFriend: friend id must be a string' );
-      return null;
-    }
-    if( typeof pin !== 'object' ) {
-      console.log( 'shareWithFriend: pin must be an object' );
-      return null;
-    }
-    if( typeof pin.id !== 'string' ) {
-      console.log( 'shareWithFriend: pin id must be a string' );
-      return null;
-    }
-    // Make a copy of the pin
-
-    var pinCopy = Object.assign({}, {alertedYet: false} ,pin);
-    // Set pin.friend to the userID of the person sending the pin
-    pinCopy.friend = user;
-    // Post the pin to the friend's firebase.
-    var friendPin = ref.child( friend.id ).child( 'pins' ).child( pin.id );
-    friendPin.set( pinCopy );
-    return true;
   }
 
   editTitle(value) {

--- a/app/components/ViewContainer.js
+++ b/app/components/ViewContainer.js
@@ -4,7 +4,7 @@ import Map from './Map';
 import DropNewPinButton from '../containers/container_dropNewPin';
 import PinList from './PinList';
 import Button from 'react-native-button';
-import { myCurrLoc } from '../lib/db/db';
+import { ref, myCurrLoc } from '../lib/db/db';
 
 const styles = StyleSheet.create({
   ViewMenu: {
@@ -42,6 +42,35 @@ export default class ViewContainer extends Component {
     this.setState({ view });
   }
 
+  shareWithFriend( pin, friend ) {
+    const { user } = this.props;
+    if( typeof user.id !== 'string' ) {
+      console.log( 'shareWithFriend: user id must be a string' );
+      return null;
+    }
+    if( typeof friend.id !== 'string' ) {
+      console.log( 'shareWithFriend: friend id must be a string' );
+      return null;
+    }
+    if( typeof pin !== 'object' ) {
+      console.log( 'shareWithFriend: pin must be an object' );
+      return null;
+    }
+    if( typeof pin.id !== 'string' ) {
+      console.log( 'shareWithFriend: pin id must be a string' );
+      return null;
+    }
+    // Make a copy of the pin
+
+    var pinCopy = Object.assign({}, {alertedYet: false} ,pin);
+    // Set pin.friend to the userID of the person sending the pin
+    pinCopy.friend = user;
+    // Post the pin to the friend's firebase.
+    var friendPin = ref.child( friend.id ).child( 'pins' ).child( pin.id );
+    friendPin.set( pinCopy );
+    return true;
+  }
+
   render() {
     const { pins, recent, friends, user, targetPin, getLocationToSave, updatePins, updateRecent, deletePin, setTarget, clearTarget } = this.props;
 
@@ -50,6 +79,7 @@ export default class ViewContainer extends Component {
       <View style={{flex: 1}}>
       { this.state.view === 'ar' ? <AR pins={pins} targetPin={targetPin} /> : void 0 }
       { this.state.view === 'map' ? <Map
+          shareWithFriend={this.shareWithFriend.bind(this)}
           getLocationToSave={getLocationToSave}
           // initialLoc={this.state.initialLoc}
           pins = {pins}
@@ -63,6 +93,7 @@ export default class ViewContainer extends Component {
           clearTarget={clearTarget}
         /> : void 0 }
       { this.state.view === 'list' ? <PinList
+          shareWithFriend={this.shareWithFriend.bind(this)}
           deletePin={deletePin}
           updatePins={updatePins}
           updateRecent={updateRecent}


### PR DESCRIPTION
This PR allows a user to share a pin with a friend by pressing 'edit pin' from the map view rather than by having to go to the list view.