### PR TITLE
fixed rendering bug!, region was confused between targetPin and state…

### DIFF
--- a/app/components/Map.js
+++ b/app/components/Map.js
@@ -59,8 +59,10 @@ export default class Map extends Component {
 
   componentWillUpdate(nextProps) {
     const {targetPin} = nextProps;
-    if(targetPin.longitude) {
-      this.goToTarget.call(this, targetPin);
+    if(this.props.targetPin.id !== targetPin.id) {
+      if(targetPin.longitude) {
+        this.goToTarget.call(this, targetPin);
+      }
     }
   }
 
@@ -121,7 +123,7 @@ export default class Map extends Component {
   }
 
   goToTarget(pinObj){
-    const {targetPin, clearTarget} = this.props
+    const {targetPin, clearTarget} = this.props;
     this.refs.map.animateToRegion(targetPin, 100);
   }
 
@@ -201,7 +203,7 @@ export default class Map extends Component {
           ref="map"
           showsUserLocation={true}
           initialRegion={stateLocation}
-          region={stateLocation}
+          region = {targetPin.longitude ? targetPin: stateLocation }
           style={styles.map}
           showsCompass={true}
           onLongPress={ (e) => {


### PR DESCRIPTION
Finally fixed the bug!
**problem:** map was not going to targetPin (whether it was shared from friend or chosen).
**diagnosis:**
So the map was not going to friends because we set region within < MapView > to be stateLocation.
**stateLocation is the UI state**
We were listening for redux state change in **targetPin** to re-render the map to a region.
But we couldn't set stateLocation to targetPin inside componentWillUpdate because it would set of a re-render. 
loop: targetPin change --> we animate to region targetPin --> but we render map in render and it notices that region = stateLocation !== targetPin --> BUG/we are in the middle of the ocean in africa.
**solution:**  
```javascript
region = {targetPin.longitude ? targetPin: stateLocation }
```
region will go to targetPin if it exists, but will go to stateLocation (usually where user is located) if no target pin is set.